### PR TITLE
feat: Revise UI/UX of GitHub repository loader

### DIFF
--- a/index.css
+++ b/index.css
@@ -147,6 +147,14 @@
     overflow: hidden;
     text-overflow: ellipsis;
   }
+  .footer-tooltip {
+    margin: 0;
+    font-size: 0.75rem;
+    color: var(--help);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
   .footer-action-btn {
     background: none;
     border: none;
@@ -414,7 +422,7 @@
   .repo-loader-form {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
+    gap: 0;
   }
   .repo-loader-form input {
     width: 350px; 
@@ -425,7 +433,11 @@
     transition: padding-right 0.2s ease;
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
-    border-right: 0;
+    border-right-width: 0;
+  }
+  .repo-loader-form input:focus {
+    position: relative;
+    z-index: 1;
   }
   .repo-loader-form input.input {
     background-color: var(--background);
@@ -434,7 +446,9 @@
     opacity: 0.7;
   }
   .repo-loader-form .btn-primary {
-    border-radius: 0;
+    height: 30px;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
   }
   .repo-loader-form .btn-secondary {
     border-top-left-radius: 0;
@@ -805,8 +819,8 @@
 
   .input:focus, .input:focus-visible {
     outline: none;
-    border-color: var(--primary);
-    box-shadow: 0 0 0 1px var(--primary);
+    border-color: var(--border);
+    box-shadow: 0 0 0 2px oklch(from var(--primary) l a b / 0.3);
   }
   .btn-ghost {
     background-color: transparent;

--- a/shared/ui/footer.tsx
+++ b/shared/ui/footer.tsx
@@ -5,8 +5,9 @@ interface FooterProps {
   onResetLayout: () => void;
   errorMessage: string | null;
   onClearError: () => void;
+  tooltipMessage: string | null;
 }
-export const Footer: FC<FooterProps> = ({ onResetLayout, errorMessage, onClearError }) => {
+export const Footer: FC<FooterProps> = ({ onResetLayout, errorMessage, onClearError, tooltipMessage }) => {
   return (
     <footer className="page-footer">
       <div className="footer-left-content">
@@ -18,7 +19,11 @@ export const Footer: FC<FooterProps> = ({ onResetLayout, errorMessage, onClearEr
         >
           <RefreshCw size={ICON_SIZE_XS} />
         </button>
-        <p className="copyright-text">{TextCopyrightTemplate.replace('{0}', new Date().getFullYear().toString())}</p>
+        {tooltipMessage ? (
+          <p className="footer-tooltip">{tooltipMessage}</p>
+        ) : (
+          <p className="copyright-text">{TextCopyrightTemplate.replace('{0}', new Date().getFullYear().toString())}</p>
+        )}
       </div>
       {errorMessage && (
         <div className="footer-error-message" role="alert">

--- a/src/domains/repository-analysis/ui/repo-loader.tsx
+++ b/src/domains/repository-analysis/ui/repo-loader.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { Play, RotateCw, Loader2 } from 'lucide-react';
+import { ArrowRight, RotateCw, Loader2 } from 'lucide-react';
 import { ICON_SIZE_XS } from '../../../../shared/config';
 interface RepoLoaderProps {
   repoUrl: string;
@@ -8,6 +8,7 @@ interface RepoLoaderProps {
   onReset: () => void;
   isRepoLoading: boolean;
   isRepoLoaded: boolean;
+  dispatch: React.Dispatch<any>;
 }
 export const RepoLoader: FC<RepoLoaderProps> = ({
   repoUrl,
@@ -16,11 +17,21 @@ export const RepoLoader: FC<RepoLoaderProps> = ({
   onReset,
   isRepoLoading,
   isRepoLoaded,
+  dispatch,
 }) => {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     onLoad();
   };
+
+  const handleMouseEnter = () => {
+    dispatch({ type: 'SET_FOOTER_TOOLTIP', payload: 'Enter the full URL of a public GitHub repository.' });
+  };
+
+  const handleMouseLeave = () => {
+    dispatch({ type: 'SET_FOOTER_TOOLTIP', payload: null });
+  };
+
   return (
     <form className="repo-loader-form" onSubmit={handleSubmit}>
       <input
@@ -31,9 +42,11 @@ export const RepoLoader: FC<RepoLoaderProps> = ({
         placeholder="Paste public GitHub URL..."
         aria-label="GitHub Repository URL"
         disabled={isRepoLoading}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
       />
       <button type="submit" className="btn btn-xs btn-primary" disabled={isRepoLoading || !repoUrl.trim()}>
-        {isRepoLoading ? <Loader2 size={ICON_SIZE_XS} className="animate-spin" /> : <Play size={ICON_SIZE_XS} />}
+        {isRepoLoading ? <Loader2 size={ICON_SIZE_XS} className="animate-spin" /> : <ArrowRight size={ICON_SIZE_XS} />}
         <span>Load</span>
       </button>
       <button

--- a/src/shell/app.tsx
+++ b/src/shell/app.tsx
@@ -33,6 +33,7 @@ type AppState = {
   localStorageError: string | null;
   transientError: string | null;
   panelWidths: number[];
+  footerTooltip: string | null;
 };
 type AppAction =
   | { type: 'SET_REPO_URL'; payload: string }
@@ -43,7 +44,8 @@ type AppAction =
   | { type: 'CLEAR_LOCAL_STORAGE_ERROR' }
   | { type: 'SET_TRANSIENT_ERROR'; payload: string | null }
   | { type: 'SET_PANEL_WIDTHS'; payload: number[] }
-  | { type: 'RESET_PANEL_WIDTHS' };
+  | { type: 'RESET_PANEL_WIDTHS' }
+  | { type: 'SET_FOOTER_TOOLTIP'; payload: string | null };
 const initialState: AppState = {
   repoUrl: '',
   repoInfo: null,
@@ -53,6 +55,7 @@ const initialState: AppState = {
   localStorageError: null,
   transientError: null,
   panelWidths: DEFAULT_PANEL_FLEX,
+  footerTooltip: null,
 };
 const getInitialState = (): AppState => {
   try {
@@ -100,6 +103,8 @@ const appReducer = (state: AppState, action: AppAction): AppState => {
         return { ...state, panelWidths: action.payload };
     case 'RESET_PANEL_WIDTHS':
         return { ...state, panelWidths: initialState.panelWidths };
+    case 'SET_FOOTER_TOOLTIP':
+        return { ...state, footerTooltip: action.payload };
     default:
       return state;
   }
@@ -110,7 +115,7 @@ export const App: FC = () => {
     }
     const [state, dispatch] = useReducer(appReducer, undefined, getInitialState);
     const [rightPanelView, setRightPanelView] = useState<string>(RightPanelViewer);
-    const { repoInfo, fileTree, repoUrl, isLoading, error, localStorageError, transientError, panelWidths } = state;
+    const { repoInfo, fileTree, repoUrl, isLoading, error, localStorageError, transientError, panelWidths, footerTooltip } = state;
     const mainGridRef = useRef<HTMLDivElement>(null);
     const animationFrameId = useRef<number | null>(null);
     const isRepoLoaded = !!repoInfo;
@@ -233,6 +238,7 @@ export const App: FC = () => {
               onReset={handleReset}
               isRepoLoading={isLoading}
               isRepoLoaded={isRepoLoaded}
+              dispatch={dispatch}
             />
           </PageHeader>
           <RepositoryProvider
@@ -272,6 +278,7 @@ export const App: FC = () => {
             onResetLayout={handleResetLayout}
             errorMessage={displayError}
             onClearError={handleClearError}
+            tooltipMessage={footerTooltip}
           />
         </div>
       </AuthProvider>


### PR DESCRIPTION
This commit revises the UI/UX of the GitHub repository loader to match the new design specifications.

Key changes include:
- **Pill Shape:** The input field and the "Load" button are now styled as a single, cohesive "pill" shape, with shared borders and squared-off adjacent corners.
- **Iconography:** The default "Load" button icon is now a right-pointing arrow, which transforms into a loader during the loading state.
- **Guidance on Hover:** A tooltip message is now displayed in the footer when the user hovers over the input field, providing just-in-time guidance.
- **Focus Style:** The input field now has a soft, elegant glow in the primary accent color when focused.
- **State Management:** The application's state management has been updated to handle the new footer tooltip message.