### PR TITLE
feat(ci): add secrets to build job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,10 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      GITHUB_CLIENT_ID: ${{ secrets.GITHUB_CLIENT_ID }}
+      GITHUB_CLIENT_SECRET: ${{ secrets.GITHUB_CLIENT_SECRET }}
+      JWT_SECRET: ${{ secrets.JWT_SECRET }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Inject GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, and JWT_SECRET as environment variables into the build job in the deployment workflow.

This allows the build process to access these values, enabling the secure configuration of the serverless functions without exposing any sensitive information in the codebase.