### PR TITLE
Refactor: Use GitHub Variables for GITHUB_CLIENT_ID

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      GITHUB_CLIENT_ID: ${{ secrets.GITHUB_CLIENT_ID }}
+      GITHUB_CLIENT_ID: ${{ vars.GITHUB_CLIENT_ID }}
       GITHUB_CLIENT_SECRET: ${{ secrets.GITHUB_CLIENT_SECRET }}
       JWT_SECRET: ${{ secrets.JWT_SECRET }}
     steps:


### PR DESCRIPTION
This commit refactors the GitHub Actions workflow to align with security best practices by using GitHub Variables for non-sensitive configuration data.

The `GITHUB_CLIENT_ID` is a public, non-sensitive value and has been moved from the `secrets` context to the `vars` context. This change correctly reflects the nature of the key without altering the application's functionality.

Sensitive keys such as `GITHUB_CLIENT_SECRET` and `JWT_SECRET` remain securely stored as GitHub Secrets.