### PR TITLE
Fix: Use relative path for entry script in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,6 @@
 </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/index.tsx"></script>
+    <script type="module" src="index.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
The application was failing to load when deployed to a subdirectory because the main script tag in `index.html` used an absolute path (`/index.tsx`). This resulted in a 404 error as the browser tried to fetch the script from the root of the domain instead of the subdirectory.

This commit changes the path to be relative (`index.tsx`), ensuring that the browser can correctly locate and load the JavaScript bundle in a subdirectory deployment environment, such as GitHub Pages.