### PR TITLE
feat: Configure environment variables for GitHub auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Server-side GitHub OAuth App credentials
+GITHUB_CLIENT_ID=your_github_client_id
+GITHUB_CLIENT_SECRET=your_github_client_secret
+
+# Secret for signing JWTs
+JWT_SECRET=your_super_secret_jwt_string
+
+# Client-side GitHub OAuth App credential
+# This should be the same value as GITHUB_CLIENT_ID
+VITE_GITHUB_CLIENT_ID=your_github_client_id

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.env
 
 # Editor directories and files
 .vscode/*

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,12 +6,11 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig(({ mode }) => {
-    const env = loadEnv(mode, '.', '');
+    const env = loadEnv(mode, process.cwd(), '');
     return {
       base: '/Sxentrie-RAG/',
       define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
+        'import.meta.env.VITE_GITHUB_CLIENT_ID': JSON.stringify(env.VITE_GITHUB_CLIENT_ID),
       },
       resolve: {
         alias: {


### PR DESCRIPTION
This commit introduces the necessary configuration to support the GitHub OAuth2 authentication flow.

- Creates a `.env.example` file to document the required server-side and client-side environment variables.
- Adds `.env` to `.gitignore` to prevent committing sensitive credentials.
- Updates `vite.config.ts` to correctly load and expose the `VITE_GITHUB_CLIENT_ID` to the frontend application, enabling the client-side part of the auth flow.
- Removes the incorrect `define` block for `GEMINI_API_KEY`.